### PR TITLE
pin numpy and scipy

### DIFF
--- a/unavco2021/README.md
+++ b/unavco2021/README.md
@@ -1,3 +1,7 @@
+# THE 2021 UNAVCO DOCKER IMAGE IS NO LONGER SUPPORTED. 
+
+---
+
 # Building the UNAVCO Docker Image and Running it in a Docker Container
 
 Note: M1 Macs are not currently supported.

--- a/unavco2022/env/unavco.yml
+++ b/unavco2022/env/unavco.yml
@@ -24,7 +24,7 @@ dependencies:
   - matplotlib
   - mintpy==1.4.1
   - netcdf4
-  - numpy
+  - numpy<1.24.0
   - openmp
   - opensarlab_lib
   - pip
@@ -36,7 +36,7 @@ dependencies:
   - pyresample
   - pyrocko
   - scikit-image
-  - scipy
+  - scipy<1.10.0
   - shapely
   - traitlets==5.1.1
   - utm


### PR DESCRIPTION
- pin numpy<1.24.0
- pin scipy<1.10.0
- deprecate unavco 2021 image